### PR TITLE
Adding a new method to download the entire catalog into a file.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 History
 -------
+0.2.1 (2014-04-29)
+++++++++++++++++++
+- Adding a new method to download the entire catalog into a file.
+
 0.2.0 (2013-01-26)
 ++++++++++++++++++
 - Issue #6: Add support for downloading full catalog in lib as well as in command line 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="pyflix2",
-    version='0.2.0',
+    version='0.2.1',
     description="A python module for accessing Netflix REST webservice, both V1 and V2 supports oauth and oob.",
     long_description=open('README.rst').read() + '\n\n' +
                              open('HISTORY.rst').read(),


### PR DESCRIPTION
The current implementation downloads the entire catalog in memory. As the catalog is currently over 1.4 GB, it's best to have an option for saving it to a file first.
